### PR TITLE
Исправляем ошибки при компиляции на SM 1.11

### DIFF
--- a/addons/sourcemod/scripting/ma_basevotes.sp
+++ b/addons/sourcemod/scripting/ma_basevotes.sp
@@ -175,6 +175,8 @@ public int MenuHandler_Ban(Menu menu, MenuAction action, int param1, int param2)
 			DisplayVoteBanMenu(param1, target);
 		}
 	}
+	
+	return 0;
 }
 
 public Action Command_Voteban(int client, int args)
@@ -322,6 +324,8 @@ public int MenuHandler_Kick(Menu menu, MenuAction action, int param1, int param2
 			DisplayVoteKickMenu(param1, target);
 		}
 	}
+	
+	return 0;
 }
 
 public Action Command_Votekick(int client, int args)
@@ -459,6 +463,8 @@ public int MenuHandler_Confirm(Menu menu, MenuAction action, int param1, int par
 		
 		ResetMenu();
 	}
+	
+	return 0;
 }
 
 public int MenuHandler_Map(Menu menu, MenuAction action, int param1, int param2)

--- a/addons/sourcemod/scripting/materialadmin.sp
+++ b/addons/sourcemod/scripting/materialadmin.sp
@@ -129,9 +129,9 @@ bool g_bCvar_Alltalk;
 int g_iCvar_ImmunityMode,
 	g_iCvar_Deadtalk;
 	
-Handle g_hTimerMute[MAXPLAYERS+1] = null,
-	g_hTimerGag[MAXPLAYERS+1] = null,
-	g_hTimerBekap = null;
+Handle g_hTimerMute[MAXPLAYERS+1],
+	g_hTimerGag[MAXPLAYERS+1],
+	g_hTimerBekap;
 	
 float g_fRetryTime = 60.0;
 

--- a/addons/sourcemod/scripting/materialadmin/function.sp
+++ b/addons/sourcemod/scripting/materialadmin/function.sp
@@ -1156,6 +1156,8 @@ public Action TimerKick(Handle timer, any iUserId)
 	int iClient = GetClientOfUserId(iUserId);
 	if (iClient)
 		KickClient(iClient, "%T", "Banneds", iClient);
+		
+	return Plugin_Continue;
 }
 
 public Action TimerBan(Handle timer, any data)
@@ -1180,6 +1182,8 @@ public Action TimerBan(Handle timer, any data)
 			LogToFile(g_sLogAction, "addip %d %s", g_iServerBanTime, sBuffer);
 #endif
 	}
+
+	return Plugin_Continue;
 }
 //-------------------------------------------------------------------------------------------------------------
 void LogOn()

--- a/addons/sourcemod/scripting/materialadmin/menu.sp
+++ b/addons/sourcemod/scripting/materialadmin/menu.sp
@@ -156,6 +156,8 @@ public int MenuHandler_Setting(Menu Mmenu, MenuAction mAction, int iClient, int 
 			ShowSetting(iClient);
 		}
 	}
+	
+	return 0;
 }
 
 //меню выбора игрока офлайн
@@ -235,6 +237,8 @@ public int MenuHandler_OfflineList(Menu Mmenu, MenuAction mAction, int iClient, 
 			BdGetInfoOffline(iClient, StringToInt(sID));
 		}
 	}
+	
+	return 0;
 }
 // online
 void ShowTargetOnline(int iClient)
@@ -390,6 +394,8 @@ public int MenuHandler_OnlineList(Menu Mmenu, MenuAction mAction, int iClient, i
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void ShowTypeMenu(int iClient)
@@ -443,6 +449,8 @@ public int MenuHandler_MenuType(Menu Mmenu, MenuAction mAction, int iClient, int
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void ShowTypeBanMenu(int iClient)
@@ -482,6 +490,8 @@ public int MenuHandler_MenuTypeBan(Menu Mmenu, MenuAction mAction, int iClient, 
 			ShowTimeMenu(iClient);
 		}
 	}
+	
+	return 0;
 }
 
 void ShowTypeMuteMenu(int iClient)
@@ -628,6 +638,8 @@ public int MenuHandler_MenuTypeMute(Menu Mmenu, MenuAction mAction, int iClient,
 		#endif
 		}
 	}
+	
+	return 0;
 }
 
 //меню выбора времени
@@ -720,6 +732,8 @@ public int MenuHandler_MenuTime(Menu Mmenu, MenuAction mAction, int iClient, int
 				ShowMuteReasonMenu(iClient);
 		}
 	}
+	
+	return 0;
 }
 
 void ShowMuteReasonMenu(int iClient)
@@ -756,7 +770,7 @@ public int MenuHandler_MenuBReason(Menu Mmenu, MenuAction mAction, int iClient, 
 			if(StrEqual("Hacking", sInfo))
 			{
 				ShowHackingMenu(iClient);
-				return;
+				return 0;
 			}
 			if(StrEqual("Own Reason", sInfo))
 			{
@@ -765,7 +779,7 @@ public int MenuHandler_MenuBReason(Menu Mmenu, MenuAction mAction, int iClient, 
 					g_bSayReasonReport[iClient] = true;
 				else
 					g_bSayReason[iClient] = true;
-				return;
+				return 0;
 			}
 			
 		#if MADEBUG
@@ -781,6 +795,8 @@ public int MenuHandler_MenuBReason(Menu Mmenu, MenuAction mAction, int iClient, 
 			}
 		}
 	}
+	
+	return 0;
 }
 
 public int MenuHandler_MenuMReason(Menu Mmenu, MenuAction mAction, int iClient, int iSlot) 
@@ -800,7 +816,7 @@ public int MenuHandler_MenuMReason(Menu Mmenu, MenuAction mAction, int iClient, 
 			{
 				PrintToChat2(iClient, "%T", "Say reason", iClient);
 				g_bSayReason[iClient] = true;
-				return;
+				return 0;
 			}
 			strcopy(g_sTarget[iClient][TREASON], sizeof(g_sTarget[][]), sInfo);
 		#if MADEBUG
@@ -809,6 +825,8 @@ public int MenuHandler_MenuMReason(Menu Mmenu, MenuAction mAction, int iClient, 
 			OnlineClientSet(iClient);
 		}
 	}
+	
+	return 0;
 }
 
 void ShowHackingMenu(int iClient)
@@ -844,6 +862,8 @@ public int MenuHandler_MenuHacking(Menu Mmenu, MenuAction mAction, int iClient, 
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void OnlineClientSet(int iClient)
@@ -908,6 +928,8 @@ public int MenuHandler_TargetList(Menu Mmenu, MenuAction mAction, int iClient, i
 			ShowListTipe(iClient, sOption);
 		}
 	}
+	
+	return 0;
 }
 
 void ShowListTipe(int iClient, char[] sOption)
@@ -957,6 +979,8 @@ public int MenuHandler_ListTipe(Menu Mmenu, MenuAction mAction, int iClient, int
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void ShowInfoMuteMenu(int iClient, int iCreated, int iEnds, int iLength, char[] sReason, char[] sNameAdmin)
@@ -1017,6 +1041,8 @@ public int MenuHandler_InfoMute(Menu Mmenu, MenuAction mAction, int iClient, int
 			}
 		}
 	}
+	
+	return 0;
 }
 //--------------------------------------------------------------------------------------------------
 // репорт меню
@@ -1062,6 +1088,8 @@ public int MenuHandler_ReportMenu(Menu Mmenu, MenuAction mAction, int iClient, i
 			ShowBanReasonMenu(iClient);
 		}
 	}
+	
+	return 0;
 }
 //---------------------------------------------------------------------------------------------------
 // управление админами
@@ -1122,6 +1150,8 @@ public int MenuHandler_SettingAdminMenu(Menu Mmenu, MenuAction mAction, int iCli
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void MenuAddAdmin(int iClient)
@@ -1179,6 +1209,8 @@ public int MenuHandler_AddAdminMenu(Menu Mmenu, MenuAction mAction, int iClient,
 				PrintToChat2(iClient, "%T", "Failed to player", iClient);
 		}
 	}
+	
+	return 0;
 }
 
 void MenuAddAdninFlag(int iClient)
@@ -1354,6 +1386,8 @@ public int MenuHandler_AddAdninFlagMenu(Menu Mmenu, MenuAction mAction, int iCli
 			}
 		}
 	}
+	
+	return 0;
 }
 
 void MenuDelAdmin(int iClient)
@@ -1411,6 +1445,8 @@ public int MenuHandler_DelAdminMenu(Menu Mmenu, MenuAction mAction, int iClient,
 				PrintToChat2(iClient, "%T", "Failed to player", iClient);
 		}
 	}
+	
+	return 0;
 }
 	
 void MenuDelAdminTyp(int iClient)
@@ -1447,5 +1483,7 @@ public int MenuHandler_DelAdminTypMenu(Menu Mmenu, MenuAction mAction, int iClie
 				BDCheckAdmins(iClient, 1);
 		}
 	}
+	
+	return 0;
 }
 #endif

--- a/addons/sourcemod/scripting/materialadmin/native.sp
+++ b/addons/sourcemod/scripting/materialadmin/native.sp
@@ -11,6 +11,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("MAGetConfigSetting", Native_GetConfigSetting);
 	CreateNative("MAGetDatabase", Native_GetDatabase);
 	CreateNative("MALog", Native_Log);
+	
+	return APLRes_Success;
 }
 
 public int Native_GetDatabase(Handle plugin, int numParams)


### PR DESCRIPTION
function "" should return an explicit value
scalar assignment to array is deprecated; use "{ <val>, ... }" instead